### PR TITLE
Add  Size annotation(Javax validators) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ TempClass object = FakeDataGenerator.getInstance().makeAndIgnore(TempClass.class
 
 ***Until now, we don't have any implementation for shortcut call the method `makeAndIgnore` like `fake`.***
 
+### Custom
+Some types may have the size of the generated value changed with the use of some customizations.
+
+Here is the list of supported customizations(**under development**):
+  - @Size(Javax validators)
+    ```java
+    /*Max parameter will be considerer*/
+    @Size(max = XXXXX)
+    ```
+
 # Report a problem
 
 You are welcome to raise new [issues](https://github.com/lramosduarte/javaFactory/issues), just
@@ -89,3 +99,5 @@ This is a new project; contributors are welcome.
 - [ ] Suport to enum Type
 - [ ] Default values
 - [ ] Ignore some attributes
+- [-] Support Javax validators
+    * **DOING** Partial support

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.lramosduarte</groupId>
     <artifactId>java-factory</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
     <name>java-factory</name>
     <url>https://github.com/lramosduarte/javaFactory</url>
@@ -73,6 +73,12 @@
             <artifactId>lombok</artifactId>
             <version>1.18.8</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/github/lramosduarte/data/Attribute.java
+++ b/src/main/java/com/github/lramosduarte/data/Attribute.java
@@ -1,6 +1,9 @@
 package com.github.lramosduarte.data;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import javax.validation.constraints.Size;
 
 
 public class Attribute {
@@ -13,12 +16,31 @@ public class Attribute {
 
     public Field field;
 
+    private int size;
+
     public static Attribute of(Field field) {
         Attribute attribute = new Attribute();
         attribute.field = field;
         attribute.name = field.getName();
         attribute.type = TypesToGenerate.getEnum(field.getType());
         return attribute;
+    }
+
+    public static Attribute ofTypesToGenerate(TypesToGenerate type) {
+        Attribute attribute = new Attribute();
+        attribute.type = type;
+        return attribute;
+    }
+
+    public Integer getLenght() {
+        this.size = this.type.size();
+        if (this.field != null) {
+            Arrays.stream(this.field.getDeclaredAnnotations())
+                .filter(a -> a instanceof Size)
+                .findFirst()
+                .ifPresent(annotation -> this.size = ((Size) annotation).max());
+        }
+        return this.size;
     }
 
 }

--- a/src/main/java/com/github/lramosduarte/fake/FakeDataGenerator.java
+++ b/src/main/java/com/github/lramosduarte/fake/FakeDataGenerator.java
@@ -53,8 +53,8 @@ public class FakeDataGenerator {
      * @return instance with random value
      * @see TypesToGenerate
      */
-    public <TypeObject> TypeObject make(TypesToGenerate type) {
-        return (TypeObject) this.MAP_GENERATOR.get(type).generate(type.size());
+    public <TypeObject> TypeObject make(Attribute attribute) {
+        return (TypeObject) this.MAP_GENERATOR.get(attribute.type).generate(attribute.getLenght());
     }
 
     /**

--- a/src/main/java/com/github/lramosduarte/fake/setter/CollectionSetter.java
+++ b/src/main/java/com/github/lramosduarte/fake/setter/CollectionSetter.java
@@ -26,7 +26,7 @@ public class CollectionSetter implements Setter, AnalyserGenerics {
         TypesToGenerate typeParam =
             this.analyseParamsGenerics((ParameterizedType) attribute.field.getGenericType(), 1).get(0);
         for (int i = 0; i < attribute.type.size(); i++) {
-            collection.add(this.fakeDataGenerator.make(typeParam));
+            collection.add(this.fakeDataGenerator.make(Attribute.ofTypesToGenerate(typeParam)));
         }
         try {
             attribute.field.set(object, collection);

--- a/src/main/java/com/github/lramosduarte/fake/setter/DefaultSetter.java
+++ b/src/main/java/com/github/lramosduarte/fake/setter/DefaultSetter.java
@@ -18,7 +18,7 @@ public class DefaultSetter implements Setter {
     @Override
     public <Instance> void setAttribute(Attribute attribute, Instance object) throws IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
         attribute.field.setAccessible(true);
-        Object value = this.fakeDataGenerator.make(attribute.type);
+        Object value = this.fakeDataGenerator.make(attribute);
         try {
             attribute.field.set(object, value);
         } catch (IllegalArgumentException ignored) {

--- a/src/main/java/com/github/lramosduarte/fake/setter/DictionarySetter.java
+++ b/src/main/java/com/github/lramosduarte/fake/setter/DictionarySetter.java
@@ -29,8 +29,8 @@ public class DictionarySetter implements Setter, AnalyserGenerics {
             this.analyseParamsGenerics((ParameterizedType) attribute.field.getGenericType(), this.QUANTITY_TO_KEY_AND_VALUE);
         for (int i = 0; i < attribute.type.size(); i++) {
             dictionary.put(
-                this.fakeDataGenerator.make(typesParams.get(0)),
-                this.fakeDataGenerator.make(typesParams.get(1))
+                this.fakeDataGenerator.make(Attribute.ofTypesToGenerate(typesParams.get(0))),
+                this.fakeDataGenerator.make(Attribute.ofTypesToGenerate(typesParams.get(1)))
             );
         }
         attribute.field.set(object, dictionary);

--- a/src/main/java/com/github/lramosduarte/fake/setter/ShortSetter.java
+++ b/src/main/java/com/github/lramosduarte/fake/setter/ShortSetter.java
@@ -17,7 +17,7 @@ public class ShortSetter implements Setter {
     @Override
     public <Instance> void setAttribute(Attribute attribute, Instance object) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         attribute.field.setAccessible(true);
-        Object value = this.fakeDataGenerator.make(attribute.type);
+        Object value = this.fakeDataGenerator.make(attribute);
         attribute.field.set(object, Number.class.getMethod("shortValue").invoke(value));
     }
 

--- a/src/test/java/com/github/lramosduarte/fake/FakeDataGeneratorTest.java
+++ b/src/test/java/com/github/lramosduarte/fake/FakeDataGeneratorTest.java
@@ -1,8 +1,10 @@
 package com.github.lramosduarte.fake;
 
 import com.github.lramosduarte.classutils.SimpleClassAttributesPrimitives;
+import com.github.lramosduarte.analyser.AnalyserImp;
 import com.github.lramosduarte.classutils.ClassWithCollections;
 import com.github.lramosduarte.classutils.ClassWithDictionarys;
+import com.github.lramosduarte.data.Attribute;
 import com.github.lramosduarte.data.TypesToGenerate;
 import com.github.lramosduarte.exception.GenerateValueException;
 
@@ -11,6 +13,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+
+import javax.validation.constraints.Size;
 
 
 public class FakeDataGeneratorTest {
@@ -26,7 +30,7 @@ public class FakeDataGeneratorTest {
     public void testGeneratorFakeDataToPrimitiveBool_returnBoolPrimitive() {
         Assertions.assertEquals(
             Boolean.class.getSimpleName(),
-            FakeDataGeneratorTest.generator.make(TypesToGenerate.BOOL).getClass().getSimpleName()
+            FakeDataGeneratorTest.generator.make(Attribute.ofTypesToGenerate(TypesToGenerate.BOOL)).getClass().getSimpleName()
         );
     }
 
@@ -34,7 +38,7 @@ public class FakeDataGeneratorTest {
     public void testGeneratorFakeDataToPrimitiveChar_returnChar() {
         Assertions.assertEquals(
             Character.class.getSimpleName(),
-            FakeDataGeneratorTest.generator.make(TypesToGenerate.CHAR).getClass().getSimpleName()
+            FakeDataGeneratorTest.generator.make(Attribute.ofTypesToGenerate(TypesToGenerate.CHAR)).getClass().getSimpleName()
         );
     }
 
@@ -42,7 +46,7 @@ public class FakeDataGeneratorTest {
     public void testGeneratorFakeDataToSmallString_returnString() {
         Assertions.assertEquals(
             String.class.getSimpleName(),
-            FakeDataGeneratorTest.generator.make(TypesToGenerate.SMALL_TEXT).getClass().getSimpleName()
+            FakeDataGeneratorTest.generator.make(Attribute.ofTypesToGenerate(TypesToGenerate.SMALL_TEXT)).getClass().getSimpleName()
         );
     }
 
@@ -50,7 +54,7 @@ public class FakeDataGeneratorTest {
     public void testGeneratorFakeDataToBigString_returnString() {
         Assertions.assertEquals(
             String.class.getSimpleName(),
-            FakeDataGeneratorTest.generator.make(TypesToGenerate.BIG_TEXT).getClass().getSimpleName()
+            FakeDataGeneratorTest.generator.make(Attribute.ofTypesToGenerate(TypesToGenerate.BIG_TEXT)).getClass().getSimpleName()
         );
     }
 
@@ -58,8 +62,20 @@ public class FakeDataGeneratorTest {
     public void testGeneratorFakeDataToNumber_returnNumber() {
         Assertions.assertEquals(
             Integer.class.getSimpleName(),
-            FakeDataGeneratorTest.generator.make(TypesToGenerate.NUMBER).getClass().getSimpleName()
+            FakeDataGeneratorTest.generator.make(Attribute.ofTypesToGenerate(TypesToGenerate.NUMBER)).getClass().getSimpleName()
         );
+    }
+
+    @Test
+    public void testGeneratorFakeDataToStringWithCustomLengthFromSizeAnnotationJavax__returnStringWithDefaultLengthChanged()
+            throws ClassNotFoundException {
+        class ClassUsingJavaxAnnotations {
+            @Size(min = 1, max = 10)
+            String atrString;
+        }
+        Attribute attribute = AnalyserImp.getAnalyser().analyse(ClassUsingJavaxAnnotations.class).iterator().next();
+        String stringWithCustomSize = FakeDataGeneratorTest.generator.make(attribute);
+        Assertions.assertNotEquals(TypesToGenerate.SMALL_TEXT.size(), stringWithCustomSize.length());
     }
 
     @Test


### PR DESCRIPTION
Now during the generation of the random string, the algorithm considers
the max size informed in the annotation and not just the fixed size of the
lib.